### PR TITLE
Build dockerfile multiarch

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -9,7 +9,7 @@ on:
 name: Clippy check
 env:
   RUSTFLAGS: "-Dwarnings" 
-  REGISTRY_IMAGE: mattfly/hanb
+  REGISTRY_IMAGE: ${{ secrets.REGISTRY_IMAGE }}  # example mattfly/hanb
 
 jobs:
   clippy_check:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -9,6 +9,7 @@ on:
 name: Clippy check
 env:
   RUSTFLAGS: "-Dwarnings" 
+  REGISTRY_IMAGE: mattfly/hanb
 
 jobs:
   clippy_check:
@@ -29,23 +30,101 @@ jobs:
           cd rust
           cargo test
 
-  push_to_registry:
-    name: Push Docker image to Docker Hub
+  build_docker:
+    name: Build docker image
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm/v7
+          - linux/arm64
+
     if: github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV     
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
         with:
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           context: .
           file: docker/rust/Dockerfile
-          tags: mattfly/hanb:latest,mattfly/hanb:${{ github.sha }}
-          push: true
+      
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"          
+      
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge_docker:
+    name: Merge docker images and push manifest
+    runs-on: ubuntu-latest
+    needs:
+      - build_docker
+    steps:
+      - name: Download meta bake definition
+        uses: actions/download-artifact@v4
+        with:
+          name: bake-meta
+          path: /tmp
+      
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ env.REGISTRY_IMAGE }}")) | "-t " + .) | join(" ")' /tmp/bake-meta.json) \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)          
+      
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' /tmp/bake-meta.json)          

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -112,10 +112,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY_IMAGE }}
       
-      - name: Login to Docker Hub
+      - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Create manifest list and push

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -91,18 +91,11 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  merge_docker:
-    name: Merge docker images and push manifest
+  merge:
     runs-on: ubuntu-latest
     needs:
       - build_docker
     steps:
-      - name: Download meta bake definition
-        uses: actions/download-artifact@v4
-        with:
-          name: bake-meta
-          path: /tmp
-      
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
@@ -113,7 +106,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
-      - name: Login to DockerHub
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
@@ -122,9 +121,9 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ env.REGISTRY_IMAGE }}")) | "-t " + .) | join(" ")' /tmp/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)          
       
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' /tmp/bake-meta.json)          
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}          

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -15,7 +15,7 @@ jobs:
   clippy_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run Clippy
         run: |
           cd rust
@@ -24,7 +24,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run cargo test
         run: |
           cd rust

--- a/rust/src/hanb.rs
+++ b/rust/src/hanb.rs
@@ -81,7 +81,7 @@ impl Board {
             } else {
                 output.push(match c {
                     ' ' => ALPHABET.chars().rev().nth(1).unwrap(),
-                    _ => ALPHABET.chars().rev().next().unwrap(),
+                    _ => ALPHABET.chars().next_back().unwrap(),
                 });
             }
         }
@@ -184,7 +184,7 @@ impl Navigator {
         let index = SIZES.find(self.level).unwrap();
         if index == SIZES.len() - 1 {
             return Err(format!(
-                "You've reached the top limit fo the universe\nColor {}",
+                "You've reached the top limit of the universe\nColor {}",
                 self.current_board().color
             ));
         }
@@ -204,7 +204,7 @@ impl Navigator {
             board = board.cells[*cell].get_board().unwrap();
         }
         if self.cell_stack.is_empty() {
-            self.level = SIZES.chars().rev().next().unwrap();
+            self.level = SIZES.chars().next_back().unwrap();
         }
         Ok(board)
     }


### PR DESCRIPTION
Fixes a typo and builds hanb dockerfile for multiple architectures

Hopefully you will have handyc/hanb in dockerhub sometime so this makes sense, for now I have it in mattfly/hanb from my fork.
